### PR TITLE
feature/주식디데일페이지_봉그래프구현

### DIFF
--- a/app/(anon)/stock/[symbol]/StockDetail.Styled.ts
+++ b/app/(anon)/stock/[symbol]/StockDetail.Styled.ts
@@ -7,25 +7,23 @@ export const StockInfo = styled.section`
   margin-bottom: 8px;
 `;
 
-export const StockName = styled.h2`
+export const StockName = styled.h1`
   font-size: 20px;
-  font-weight: bold;
   margin: 4px 0;
 `;
 
-export const StockPrice = styled.p`
+export const StockPrice = styled.h2`
   font-size: 24px;
-  font-weight: bold;
   margin: 4px 0;
 `;
 
 export const StockDiff = styled.p`
   font-size: 14px;
-  color: #999;
+  color: var(--gray-700);
   margin: 4px 0;
 
   span {
-    color: #e53935; /* 상승 시 빨간색 */
+    color:rgb(13, 0, 255);
     font-weight: bold;
   }
 `;
@@ -42,37 +40,12 @@ export const TabItem = styled.div<{ $active?: boolean }>`
   text-align: center;
   padding: 12px 0;
   font-weight: ${({ $active }) => ($active ? 'bold' : 'normal')};
-  color: ${({ $active }) => ($active ? '#000' : '#666')};
-  border-bottom: ${({ $active }) => ($active ? '2px solid #000' : 'none')};
-  cursor: pointer;
+  color: ${({ $active }) => ($active ? 'var(--black-color)' : 'var(--gray-900)')};
+  border-bottom: ${({ $active }) => ($active ? '2px solid var(--black-color)' : 'none')};
 `;
 
 export const ChartContainer = styled.section`
   padding: 16px;
-`;
-
-export const ChartImage = styled.div`
-  position: relative;
-  height: 200px;
-  border: 1px solid #eee;
-  border-radius: 8px;
-  overflow: hidden;
-`;
-
-export const ChartLabelTop = styled.span`
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  font-size: 12px;
-  color: var(--gray-700);
-`;
-
-export const ChartLabelBottom = styled.span`
-  position: absolute;
-  bottom: 8px;
-  left: 8px;
-  font-size: 12px;
-  color: var(--gray-700);
 `;
 
 export const PeriodSelector = styled.div`
@@ -85,19 +58,8 @@ export const PeriodItem = styled.button<{ $active?: boolean }>`
   background: none;
   border: none;
   font-size: 14px;
-  padding: 8px 20px;
+  padding: 8px 26px;
   margin: 0 4px;
-  color: ${({ $active }) => ($active ? '#000' : '#666')};
+  color: ${({ $active }) => ($active ? 'var(--black-color)' : 'var(--gray-900)')};
   font-weight: ${({ $active }) => ($active ? 'bold' : 'normal')};
-`;
-
-export const TradeButton = styled.button`
-  width: calc(100% - 32px);
-  margin: 16px;
-  padding: 16px;
-  background-color: #007aff;
-  color: #fff;
-  font-size: 16px;
-  border: none;
-  border-radius: 8px;
 `;

--- a/app/(anon)/stock/[symbol]/StockDetail.Styled.ts
+++ b/app/(anon)/stock/[symbol]/StockDetail.Styled.ts
@@ -8,19 +8,19 @@ export const StockInfo = styled.section`
 `;
 
 export const StockName = styled.h1`
-  font-size: 20px;
+  font-size: 22px;
   margin: 4px 0;
 `;
 
 export const StockPrice = styled.h2`
-  font-size: 24px;
+  font-size: 20px;
   margin: 4px 0;
 `;
 
 export const StockDiff = styled.p`
-  font-size: 14px;
+  font-size: 12px;
   color: var(--gray-700);
-  margin: 4px 0;
+  margin: 4px 0 10px 0;
 
   span {
     color:rgb(13, 0, 255);
@@ -39,6 +39,7 @@ export const TabItem = styled.div<{ $active?: boolean }>`
   flex: 1;
   text-align: center;
   padding: 12px 0;
+  font-size: 14px;
   font-weight: ${({ $active }) => ($active ? 'bold' : 'normal')};
   color: ${({ $active }) => ($active ? 'var(--black-color)' : 'var(--gray-900)')};
   border-bottom: ${({ $active }) => ($active ? '2px solid var(--black-color)' : 'none')};

--- a/app/(anon)/stock/[symbol]/StockDetail.Styled.ts
+++ b/app/(anon)/stock/[symbol]/StockDetail.Styled.ts
@@ -2,6 +2,10 @@
 
 import styled from "styled-components";
 
+export const StockContainer = styled.div`
+  padding: 50px 20px ;
+`;
+
 export const StockInfo = styled.section`
   padding: 0 16px;
   margin-bottom: 8px;
@@ -43,6 +47,7 @@ export const TabItem = styled.div<{ $active?: boolean }>`
   font-weight: ${({ $active }) => ($active ? 'bold' : 'normal')};
   color: ${({ $active }) => ($active ? 'var(--black-color)' : 'var(--gray-900)')};
   border-bottom: ${({ $active }) => ($active ? '2px solid var(--black-color)' : 'none')};
+  cursor: pointer;
 `;
 
 export const ChartContainer = styled.section`

--- a/app/(anon)/stock/[symbol]/components/DraggableScrollContainer.tsx
+++ b/app/(anon)/stock/[symbol]/components/DraggableScrollContainer.tsx
@@ -1,0 +1,60 @@
+// DraggableScrollContainer.tsx
+import React, { useRef, useState, useLayoutEffect } from 'react';
+
+interface DraggableScrollContainerProps {
+    children: React.ReactNode;
+    style?: React.CSSProperties;
+  }
+
+const DraggableScrollContainer: React.FC<DraggableScrollContainerProps> = ({ children, style }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  useLayoutEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = containerRef.current.scrollWidth;
+    }
+  }, []);
+
+  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    setIsDragging(true);
+    if (containerRef.current) {
+      setStartX(e.pageX - containerRef.current.offsetLeft);
+      setScrollLeft(containerRef.current.scrollLeft);
+    }
+  };
+
+
+  const onMouseLeave = () => {
+    setIsDragging(false);
+  };
+
+  const onMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isDragging || !containerRef.current) return;
+    e.preventDefault();
+    const x = e.pageX - containerRef.current.offsetLeft;
+    const walk = (x - startX) * 2; // 스크롤 속도 조절
+    containerRef.current.scrollLeft = scrollLeft - walk;
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ overflowX: 'auto', cursor: isDragging ? 'grabbing' : 'grab', ...style }}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+      onMouseUp={onMouseUp}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DraggableScrollContainer;

--- a/app/(anon)/stock/[symbol]/components/StockChart.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockChart.tsx
@@ -24,7 +24,7 @@ interface StockChartProps {
 }
 
 const StockChart = ({ symbol }: StockChartProps) => {
-  const [activePeriod, setActivePeriod] = useState<string>('D'); 
+  const [activePeriod, setActivePeriod] = useState<string>('1m'); 
 
   useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);
@@ -34,7 +34,6 @@ const StockChart = ({ symbol }: StockChartProps) => {
     }
   }, []);
 
-  // 탭 클릭 시 activePeriod 업데이트 및 URL 쿼리 파라미터 반영
   const handlePeriodClick = (period: string) => {
     setActivePeriod(period);
 

--- a/app/(anon)/stock/[symbol]/components/StockChart.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockChart.tsx
@@ -1,49 +1,67 @@
 'use client';
 
-import React, { useState } from 'react';
+// 005930 (삼성전자)
+// 000660 (SK hynix)
+// 035420 (NAVER)
+// 051910 (LG화학)
+// 207940 (삼성바이오로직스)
+// 005380 (현대차)
+// 068270 (셀트리온)
+// 000270 (기아)
+// 003550 (LG전자)
+// 034730 (카카오)
+
+import React, { useState, useEffect } from 'react';
 import {
   ChartContainer,
-  ChartImage,
-  ChartLabelTop,
-  ChartLabelBottom,
   PeriodSelector,
   PeriodItem,
 } from '@/app/(anon)/stock/[symbol]/StockDetail.Styled';
+import StockChartImage from './StockChartImage';
 
 interface StockChartProps {
   symbol: string;
 }
 
 const StockChart = ({ symbol }: StockChartProps) => {
-  const [activePeriod, setActivePeriod] = useState<string>('분'); 
-  // 탭 클릭 시 활성화된 탭 상태 업데이트
+  const [activePeriod, setActivePeriod] = useState<string>('D'); 
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(window.location.search);
+    const period = queryParams.get('p');
+    if (period) {
+      setActivePeriod(period);
+    }
+  }, []);
+
+  // 탭 클릭 시 activePeriod 업데이트 및 URL 쿼리 파라미터 반영
   const handlePeriodClick = (period: string) => {
     setActivePeriod(period);
+
+    const queryString = new URLSearchParams(window.location.search);
+    queryString.set('p', period);
+    window.history.replaceState(null, '', `?${queryString.toString()}`);
   };
 
   return (
     <>
-      <h3>{symbol} 차트</h3>
       <ChartContainer>
-        <ChartImage>
-          <ChartLabelTop>최고 16,280원</ChartLabelTop>
-          <ChartLabelBottom>최저 13,510원</ChartLabelBottom>
-        </ChartImage>
+        <StockChartImage symbol={symbol} activePeriod={activePeriod} />
       </ChartContainer>
       <PeriodSelector>
-        <PeriodItem $active={activePeriod === '분'} onClick={() => handlePeriodClick('분')}>
-          분
+        <PeriodItem $active={activePeriod === '1m'} onClick={() => handlePeriodClick('1m')}>
+          1분
         </PeriodItem>
-        <PeriodItem $active={activePeriod === '일'} onClick={() => handlePeriodClick('일')}>
+        <PeriodItem $active={activePeriod === 'D'} onClick={() => handlePeriodClick('D')}>
           일
         </PeriodItem>
-        <PeriodItem $active={activePeriod === '주'} onClick={() => handlePeriodClick('주')}>
+        <PeriodItem $active={activePeriod === 'W'} onClick={() => handlePeriodClick('W')}>
           주
         </PeriodItem>
-        <PeriodItem $active={activePeriod === '월'} onClick={() => handlePeriodClick('월')}>
+        <PeriodItem $active={activePeriod === 'M'} onClick={() => handlePeriodClick('M')}>
           월
         </PeriodItem>
-        <PeriodItem $active={activePeriod === '년'} onClick={() => handlePeriodClick('년')}>
+        <PeriodItem $active={activePeriod === 'Y'} onClick={() => handlePeriodClick('Y')}>
           년
         </PeriodItem>
       </PeriodSelector>

--- a/app/(anon)/stock/[symbol]/components/StockChartImage.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockChartImage.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState, useRef } from 'react';
+import { Chart } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, TimeScale, Tooltip, Legend } from 'chart.js';
+import { CandlestickController, CandlestickElement } from 'chartjs-chart-financial';
+import 'chartjs-chart-financial';
+import 'chartjs-adapter-date-fns';
+
+// chart.js 등록
+ChartJS.register(CategoryScale, LinearScale, CandlestickController, TimeScale, CandlestickElement, Tooltip, Legend);
+
+interface StockDataItem {
+  stck_bsop_date: string;
+  stck_cntg_hour : string;
+  stck_oprc: string;
+  stck_hgpr: string;
+  stck_lwpr: string;
+  stck_clpr: string;
+  stck_prpr : string;
+}
+
+interface StockChartImageProps {
+  symbol: string;
+  activePeriod: string;
+}
+
+interface FinancialDataset {
+  label: string;
+  data: {
+    x: Date;
+    o: number;
+    h: number;
+    l: number;
+    c: number;
+  }[];
+  barThickness?: number;
+  upColor: string;
+  downColor: string;
+  unchangedColor: string;
+}
+
+interface ChartData {
+  datasets: FinancialDataset[];
+}
+
+const StockChartImage = ({ symbol, activePeriod }: StockChartImageProps) => {
+  const [chartData, setChartData] = useState<ChartData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  // 스크롤 가능한 컨테이너에 ref를 할당합니다.
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchChartData = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        let response;
+        // 분봉 차트 API 호출
+        if (activePeriod === '1m') {
+          response = await fetch(`/api/minChart?symbol=${symbol}`);  // 분봉 차트 API
+        } else {
+          response = await fetch(`/api/stockChart?symbol=${symbol}&activePeriod=${activePeriod}`);  // 기존 봉 차트 API
+        }
+
+        const data = await response.json();
+
+        const candlestickData = data.output2.map((item: StockDataItem) => {
+            const dateStr = item.stck_bsop_date; // "20250225"
+            const timeStr = item.stck_cntg_hour; // "123000"
+          
+            if (dateStr) {
+              // 날짜만 있는 경우
+              const year = parseInt(dateStr.substring(0, 4), 10);
+              const month = parseInt(dateStr.substring(4, 6), 10) - 1;
+              const day = parseInt(dateStr.substring(6, 8), 10);
+          
+              return {
+                x: new Date(year, month, day), // 00:00:00 고정
+                o: Number(item.stck_oprc),
+                h: Number(item.stck_hgpr),
+                l: Number(item.stck_lwpr),
+                c: Number(item.stck_clpr),
+              };
+            } else if (timeStr) {
+              // 시간만 있는 경우 (오늘 날짜 기준)
+              const now = new Date();
+              const hours = parseInt(timeStr.substring(0, 2), 10);
+              const minutes = parseInt(timeStr.substring(2, 4), 10);
+          
+              return {
+                x: new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, 0),
+                o: Number(item.stck_oprc),
+                h: Number(item.stck_hgpr),
+                l: Number(item.stck_lwpr),
+                c: Number(item.stck_prpr),
+              };
+            }
+          
+            console.warn("Neither dateStr nor timeStr is available:", item);
+            return null;
+          }).filter(Boolean);
+          
+
+        console.log('Candlestick Data:', candlestickData);
+
+        setChartData({
+          datasets: [
+            {
+              label: `${symbol} 봉 차트`,
+              data: candlestickData,
+              barThickness: 7, // 캔들 너비를 고정 (원하는 값으로 조정)
+              upColor: 'rgba(0, 0, 255, 1)',
+              downColor: 'rgb(255, 0, 0)',
+              unchangedColor: '#999'
+            }
+          ]
+        });
+      } catch (error) {
+        console.error('차트 데이터 불러오기 오류:', error);
+        setError('데이터를 불러오는 중 오류가 발생했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchChartData();
+  }, [symbol, activePeriod]);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = containerRef.current.scrollWidth;
+    }
+  }, [chartData]);
+
+  if (loading) return <div>차트 로딩 중...</div>;
+  if (error) return <div>{error}</div>;
+  if (!chartData) return <div>차트를 불러올 수 없습니다.</div>;
+
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '400px', overflowX: 'auto' }}>
+      <div style={{ width: '1500px', height: '100%' }}>
+        <Chart
+          type="candlestick"
+          data={chartData}
+          options={{
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                type: 'time',
+                time: {
+                  unit: activePeriod === 'Y' ? 'year' : activePeriod === 'M' ? 'month' : activePeriod === 'W' ? 'week'  : activePeriod === 'D' ? 'day' : 'minute',
+                },
+                offset: false,
+              },
+              y: {
+                position: 'right',
+              },
+            },
+            plugins: {
+                tooltip: {
+                  enabled: true,
+                  position: 'average',  // 툴팁을 데이터 중앙에 정렬
+                  yAlign: 'bottom',     // 툴팁을 위쪽으로 배치
+                  displayColors: false, // 색상 박스 제거 (더 깔끔하게)
+                  callbacks: {
+                    label: function (context) {
+                      const { o, h, l, c } = context.raw as { o: number, h: number, l: number, c: number }; // 원본 데이터에서 값 가져오기
+                      return [`시가: ${o}`, `고가: ${h}`, `저가: ${l}`, `종가: ${c}`];
+                    },
+                  },
+                },
+                legend: {
+                    display: false,
+                  },
+                },
+                interaction: {
+                  mode: 'point',
+                  intersect: false,
+                },           
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default StockChartImage;

--- a/app/(anon)/stock/[symbol]/components/StockClient.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockClient.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import StockDetailTabs from "@/app/(anon)/stock/[symbol]/components/StockDetailTabs";
+import StockDetailTitle from "@/app/(anon)/stock/[symbol]/components/StockDetailTitle";
+import { StockContainer } from "@/app/(anon)/stock/[symbol]/StockDetail.Styled";
+
+
+interface StockClientProps {
+    symbol: string;
+  }
+
+const stockClientPage = ({ symbol }: StockClientProps) => {
+
+  // TODO: 현재가 받아오기
+  const initialPrice = 77777;
+
+  return (
+    <div>
+      <StockContainer>
+      <StockDetailTitle symbol={symbol} initialPrice={initialPrice} />
+      <StockDetailTabs symbol={symbol} initialPrice={initialPrice}/>
+      </StockContainer>
+    </div>
+  );
+};
+
+export default stockClientPage;

--- a/app/(anon)/stock/[symbol]/components/StockDetailTabs.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockDetailTabs.tsx
@@ -15,15 +15,20 @@ type TabType = 'chart' | 'orderbook' | 'info';
 
 interface StockDetailTabsProps {
   symbol: string;
+  initialPrice: number;
 }
 
-const StockDetailTabs = ({ symbol }: StockDetailTabsProps) => {
+const StockDetailTabs = ({ symbol, initialPrice }: StockDetailTabsProps) => {
   const [activeTab, setActiveTab] = useState<TabType>('chart');
   const router = useRouter();  // useRouter 훅 사용
 
   const handleTabClick = (tab: TabType) => {
     setActiveTab(tab);
     router.push(`/stock/${symbol}?tab=${tab}`);  // tab을 쿼리 파라미터로 업데이트
+  };
+
+  const handleTradeClick = () => {
+    router.push(`/user/tradeaction?s=${symbol}&type=sell&initialPrice=${initialPrice}`);
   };
 
   const renderTabContent = () => {
@@ -66,7 +71,7 @@ const StockDetailTabs = ({ symbol }: StockDetailTabsProps) => {
         </TabItem>
       </TabMenu>
       {renderTabContent()}
-      <button>거래하기</button>
+      <button onClick={handleTradeClick}>거래하기</button>
     </>
   );
 };

--- a/app/(anon)/stock/[symbol]/components/StockDetailTabs.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockDetailTabs.tsx
@@ -28,7 +28,7 @@ const StockDetailTabs = ({ symbol, initialPrice }: StockDetailTabsProps) => {
   };
 
   const handleTradeClick = () => {
-    router.push(`/user/tradeaction?s=${symbol}&type=sell&initialPrice=${initialPrice}`);
+    router.push(`/user/tradeaction?s=${symbol}&initialPrice=${initialPrice}&type=buy`);
   };
 
   const renderTabContent = () => {

--- a/app/(anon)/stock/[symbol]/components/StockDetailTabs.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockDetailTabs.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import {
   TabMenu,
   TabItem,
-  TradeButton,
 } from '@/app/(anon)/stock/[symbol]/StockDetail.Styled';
 
 import StockChart from '@/app/(anon)/stock/[symbol]/components/StockChart';
@@ -19,6 +19,12 @@ interface StockDetailTabsProps {
 
 const StockDetailTabs = ({ symbol }: StockDetailTabsProps) => {
   const [activeTab, setActiveTab] = useState<TabType>('chart');
+  const router = useRouter();  // useRouter 훅 사용
+
+  const handleTabClick = (tab: TabType) => {
+    setActiveTab(tab);
+    router.push(`/stock/${symbol}?tab=${tab}`);  // tab을 쿼리 파라미터로 업데이트
+  };
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -27,7 +33,7 @@ const StockDetailTabs = ({ symbol }: StockDetailTabsProps) => {
       case 'orderbook':
         return (
           <div>
-            <p>여기에 호가창 내용 렌더링</p>
+            <p>개발중인 서비스 입니다</p>
           </div>
         );
       case 'info':
@@ -42,26 +48,26 @@ const StockDetailTabs = ({ symbol }: StockDetailTabsProps) => {
       <TabMenu>
         <TabItem
           $active={activeTab === 'chart'}
-          onClick={() => setActiveTab('chart')}
+          onClick={() => handleTabClick('chart')}
         >
           차트
         </TabItem>
         <TabItem
           $active={activeTab === 'orderbook'}
-          onClick={() => setActiveTab('orderbook')}
+          onClick={() => handleTabClick('orderbook')}
         >
           호가
         </TabItem>
         <TabItem
           $active={activeTab === 'info'}
-          onClick={() => setActiveTab('info')}
+          onClick={() => handleTabClick('info')}
         >
           종목정보
         </TabItem>
       </TabMenu>
       {renderTabContent()}
-      <TradeButton>거래하기</TradeButton>
-      </>
+      <button>거래하기</button>
+    </>
   );
 };
 

--- a/app/(anon)/stock/[symbol]/components/StockDetailTitle.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockDetailTitle.tsx
@@ -9,11 +9,16 @@ import {
   StockDiff
 } from '@/app/(anon)/stock/[symbol]/StockDetail.Styled';
 
-export default function StockDetailTitle({ symbol }: { symbol: string }) {
+interface StockDetailTitleProps {
+  symbol: string;
+  initialPrice: number;
+}
+
+export default function StockDetailTitle({ symbol, initialPrice }: StockDetailTitleProps) {
   return (
       <StockInfo>
         <StockName>{symbol}</StockName>
-        <StockPrice>56,900원</StockPrice>
+        <StockPrice>{initialPrice.toLocaleString()}원</StockPrice>
         <StockDiff>
           어제보다 <span>+315원 (1.9%)</span>
         </StockDiff>

--- a/app/(anon)/stock/[symbol]/components/StockDetailTitle.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockDetailTitle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+
 import {
   StockInfo,
   StockName,

--- a/app/(anon)/stock/[symbol]/components/StockModalContainer.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockModalContainer.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Modal from "@/app/components/Modal";
+import { useState } from "react";
+
+const StockModalContainer = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const closeModal = () => setIsModalOpen(false);
+
+  return (
+    <div>
+      <Modal isOpen={isModalOpen} onClose={closeModal}>
+        <h2>오늘은 휴장일 입니다.</h2>
+      </Modal>
+    </div>
+  );
+};
+
+export default StockModalContainer;

--- a/app/(anon)/stock/[symbol]/components/StockModalContainer.tsx
+++ b/app/(anon)/stock/[symbol]/components/StockModalContainer.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import Modal from "@/app/components/Modal";
-import { useState } from "react";
+import Modal from "@/app/components/modal/Modal";
 
-const StockModalContainer = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+interface StockModalContainerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
 
-  const closeModal = () => setIsModalOpen(false);
-
+const StockModalContainer = ({ isOpen, onClose }: StockModalContainerProps) => {
   return (
-    <div>
-      <Modal isOpen={isModalOpen} onClose={closeModal}>
-        <h2>오늘은 휴장일 입니다.</h2>
-      </Modal>
-    </div>
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <h5>오늘은 휴장일입니다.</h5>
+    </Modal>
   );
 };
 

--- a/app/(anon)/stock/[symbol]/page.tsx
+++ b/app/(anon)/stock/[symbol]/page.tsx
@@ -9,6 +9,9 @@ interface Props {
 const stockDetailPage = async ({ params }: Props) => {
   const { symbol } = await params; 
 
+  // TODO: 현재가 받아오기
+  const initialPrice = 77777;
+
   if (!symbol) {
     return <p>잘못된 요청입니다.</p>;
   }
@@ -17,8 +20,8 @@ const stockDetailPage = async ({ params }: Props) => {
 
   return (
     <div>
-      <StockDetailTitle symbol={decodedSymbol} />
-      <StockDetailTabs symbol={decodedSymbol} />
+      <StockDetailTitle symbol={decodedSymbol} initialPrice={initialPrice} />
+      <StockDetailTabs symbol={decodedSymbol} initialPrice={initialPrice}/>
     </div>
   );
 };

--- a/app/(anon)/stock/[symbol]/page.tsx
+++ b/app/(anon)/stock/[symbol]/page.tsx
@@ -1,16 +1,12 @@
+import StockClient from "@/app/(anon)/stock/[symbol]/components/StockClient";
 import React from "react";
-import StockDetailTabs from "@/app/(anon)/stock/[symbol]/components/StockDetailTabs";
-import StockDetailTitle from "@/app/(anon)/stock/[symbol]/components/StockDetailTitle";
 
 interface Props {
   params: { symbol: string }; 
 }
 
-const stockDetailPage = async ({ params }: Props) => {
-  const { symbol } = await params; 
-
-  // TODO: 현재가 받아오기
-  const initialPrice = 77777;
+const StockDetailPage = async ({ params }: Props) => {
+  const { symbol } = await params;
 
   if (!symbol) {
     return <p>잘못된 요청입니다.</p>;
@@ -20,10 +16,10 @@ const stockDetailPage = async ({ params }: Props) => {
 
   return (
     <div>
-      <StockDetailTitle symbol={decodedSymbol} initialPrice={initialPrice} />
-      <StockDetailTabs symbol={decodedSymbol} initialPrice={initialPrice}/>
+      <StockClient symbol={decodedSymbol} />
     </div>
   );
 };
 
-export default stockDetailPage;
+export default StockDetailPage;
+

--- a/app/api/minChart/route.ts
+++ b/app/api/minChart/route.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+
+export async function GET(req: Request) {
+  try {
+    const url = 'https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice';
+    
+    const getCurrentTime = (): string => {
+      const now = new Date();
+      const hours = now.getHours().toString().padStart(2, '0'); // 시
+      const minutes = now.getMinutes().toString().padStart(2, '0'); // 분
+  
+      return `${hours}${minutes}00`;
+  };
+
+    // URLSearchParams로 쿼리 파라미터 생성
+    const params = new URLSearchParams({
+      FID_ETC_CLS_CODE: "",
+      FID_COND_MRKT_DIV_CODE: 'J',
+      FID_INPUT_ISCD: req.url.split('?')[1].split('&')[0].split('=')[1],
+      FID_INPUT_DATE_1: getCurrentTime(),
+      FID_PW_DATA_INCU_YN: 'Y',
+    });
+
+    const response = await axios.get(`${url}?${params.toString()}`, {
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'authorization': `Bearer ${process.env.KIS_ACCESS_TOKEN}`,
+        'appkey': process.env.KIS_APP_KEY!,
+        'appsecret': process.env.KIS_APP_SECRET!,
+        'tr_id': 'FHKST03010200',
+        'custtype': 'P',
+      },
+    });
+
+    return new Response(JSON.stringify(response.data), { status: 200 });
+  } catch (error: unknown) {
+    console.error('API 요청 실패:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(JSON.stringify({ message: '데이터 가져오기 실패', error: errorMessage }), { status: 500 });
+  }
+}

--- a/app/api/minChart/route.ts
+++ b/app/api/minChart/route.ts
@@ -4,35 +4,63 @@ export async function GET(req: Request) {
   try {
     const url = 'https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice';
     
-    const getCurrentTime = (): string => {
-      const now = new Date();
-      const hours = now.getHours().toString().padStart(2, '0'); // 시
-      const minutes = now.getMinutes().toString().padStart(2, '0'); // 분
-  
-      return `${hours}${minutes}00`;
-  };
+    const getCurrentTime = (offset: number): string => {
+      const now = new Date();  // 현재 시간 받아오기
+      
+      // 장 마감 시간 설정 (15:15)
+      const marketCloseTime = new Date();
+      marketCloseTime.setHours(15, 15, 0, 0);
 
-    // URLSearchParams로 쿼리 파라미터 생성
-    const params = new URLSearchParams({
-      FID_ETC_CLS_CODE: "",
-      FID_COND_MRKT_DIV_CODE: 'J',
-      FID_INPUT_ISCD: req.url.split('?')[1].split('&')[0].split('=')[1],
-      FID_INPUT_DATE_1: getCurrentTime(),
-      FID_PW_DATA_INCU_YN: 'Y',
+      const marketOpenTime = new Date();
+      marketOpenTime.setHours(9, 0, 0, 0); 
+    
+      let resultTime = now;
+    
+      if (now >= marketCloseTime || now < marketOpenTime) {
+        resultTime = new Date();
+        resultTime.setHours(15, 15, 0, 0);
+    
+        // 이후에는 31분씩 빼기
+        resultTime.setMinutes(resultTime.getMinutes() - offset * 31); 
+      } else {
+        // 장이 열려있을 때는 31분 간격으로 현재 시간에서 설정
+        resultTime.setMinutes(resultTime.getMinutes() - offset * 31);
+      }
+    
+      // 결과 시간은 00초로 고정하여 반환
+      const hours = resultTime.getHours().toString().padStart(2, '0');
+      const minutes = resultTime.getMinutes().toString().padStart(2, '0');
+    
+      return `${hours}${minutes}00`;  // HHMM00 형식
+    };
+    
+    const requests = Array.from({ length: 4 }, (_, i) => {
+      const formattedTime = getCurrentTime(i);
+      // URLSearchParams로 쿼리 파라미터 생성
+      const params = new URLSearchParams({
+        FID_ETC_CLS_CODE: '',
+        FID_COND_MRKT_DIV_CODE: 'J',
+        FID_INPUT_ISCD: req.url.split('?')[1].split('&')[0].split('=')[1],
+        FID_INPUT_HOUR_1: formattedTime,
+        FID_PW_DATA_INCU_YN: 'N',
+      });
+
+      console.log('Processing time:', formattedTime);
+
+      return axios.get(`${url}?${params.toString()}`, {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'authorization': `Bearer ${process.env.KIS_ACCESS_TOKEN}`,
+          'appkey': process.env.KIS_APP_KEY!,
+          'appsecret': process.env.KIS_APP_SECRET!,
+          'tr_id': 'FHKST03010200',
+          'custtype': 'P',
+        },
+      }).then(response => response.data);
     });
 
-    const response = await axios.get(`${url}?${params.toString()}`, {
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'authorization': `Bearer ${process.env.KIS_ACCESS_TOKEN}`,
-        'appkey': process.env.KIS_APP_KEY!,
-        'appsecret': process.env.KIS_APP_SECRET!,
-        'tr_id': 'FHKST03010200',
-        'custtype': 'P',
-      },
-    });
-
-    return new Response(JSON.stringify(response.data), { status: 200 });
+    const data = await Promise.all(requests);  // 모든 요청 처리 완료 후 데이터 반환
+    return new Response(JSON.stringify(data), { status: 200 });
   } catch (error: unknown) {
     console.error('API 요청 실패:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/app/api/minChart/route.ts
+++ b/app/api/minChart/route.ts
@@ -1,53 +1,45 @@
-import axios from 'axios';
-
 export async function GET(req: Request) {
   try {
     const url = 'https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice';
     
     const getCurrentTime = (offset: number): string => {
-      const now = new Date();  // 현재 시간 받아오기
-      
-      // 장 마감 시간 설정 (15:15)
+      const now = new Date();  
       const marketCloseTime = new Date();
       marketCloseTime.setHours(15, 15, 0, 0);
-
       const marketOpenTime = new Date();
       marketOpenTime.setHours(9, 0, 0, 0); 
-    
+
       let resultTime = now;
-    
       if (now >= marketCloseTime || now < marketOpenTime) {
         resultTime = new Date();
         resultTime.setHours(15, 15, 0, 0);
-    
-        // 이후에는 31분씩 빼기
         resultTime.setMinutes(resultTime.getMinutes() - offset * 31); 
       } else {
-        // 장이 열려있을 때는 31분 간격으로 현재 시간에서 설정
         resultTime.setMinutes(resultTime.getMinutes() - offset * 31);
       }
-    
-      // 결과 시간은 00초로 고정하여 반환
+
       const hours = resultTime.getHours().toString().padStart(2, '0');
       const minutes = resultTime.getMinutes().toString().padStart(2, '0');
-    
-      return `${hours}${minutes}00`;  // HHMM00 형식
+
+      return `${hours}${minutes}00`;  
     };
     
-    const requests = Array.from({ length: 4 }, (_, i) => {
+    const symbol = req.url.split('?')[1].split('&')[0].split('=')[1];
+
+    const requests = Array.from({ length: 4 }, async (_, i) => {
       const formattedTime = getCurrentTime(i);
-      // URLSearchParams로 쿼리 파라미터 생성
       const params = new URLSearchParams({
         FID_ETC_CLS_CODE: '',
         FID_COND_MRKT_DIV_CODE: 'J',
-        FID_INPUT_ISCD: req.url.split('?')[1].split('&')[0].split('=')[1],
+        FID_INPUT_ISCD: symbol,
         FID_INPUT_HOUR_1: formattedTime,
         FID_PW_DATA_INCU_YN: 'N',
       });
 
       console.log('Processing time:', formattedTime);
 
-      return axios.get(`${url}?${params.toString()}`, {
+      const response = await fetch(`${url}?${params.toString()}`, {
+        method: 'GET',
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
           'authorization': `Bearer ${process.env.KIS_ACCESS_TOKEN}`,
@@ -56,10 +48,16 @@ export async function GET(req: Request) {
           'tr_id': 'FHKST03010200',
           'custtype': 'P',
         },
-      }).then(response => response.data);
+      });
+
+      if (!response.ok) {
+        throw new Error(`API 요청 실패: ${response.status}`);
+      }
+
+      return response.json();
     });
 
-    const data = await Promise.all(requests);  // 모든 요청 처리 완료 후 데이터 반환
+    const data = await Promise.all(requests);  
     return new Response(JSON.stringify(data), { status: 200 });
   } catch (error: unknown) {
     console.error('API 요청 실패:', error);

--- a/app/api/stockChart/route.ts
+++ b/app/api/stockChart/route.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+
+export async function GET(req: Request) {
+  try {
+    const url = 'https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice';
+    
+    const getCurrentDate = (): string => {
+        const today = new Date();
+        const year = today.getFullYear(); // 연도
+        const month = (today.getMonth() + 1).toString().padStart(2, '0'); // 월 (0부터 시작하므로 +1 해줌)
+        const day = today.getDate().toString().padStart(2, '0'); // 일
+      
+        return `${year}${month}${day}`; // YYYYMMDD 형식으로 반환
+    };
+
+    // URLSearchParams로 쿼리 파라미터 생성
+    const params = new URLSearchParams({
+      FID_COND_MRKT_DIV_CODE: 'J',
+      FID_INPUT_ISCD: req.url.split('?')[1].split('&')[0].split('=')[1],  // 요청된 symbol 추출
+      FID_INPUT_DATE_1: '19871231',
+      FID_INPUT_DATE_2: getCurrentDate(),
+      FID_PERIOD_DIV_CODE: req.url.split('?')[1].split('&')[1].split('=')[1], // 요청된 activePeriod 추출
+      FID_ORG_ADJ_PRC: '1',
+    });
+
+    const response = await axios.get(`${url}?${params.toString()}`, {
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'authorization': `Bearer ${process.env.KIS_ACCESS_TOKEN}`,
+        'appkey': process.env.KIS_APP_KEY!,
+        'appsecret': process.env.KIS_APP_SECRET!,
+        'tr_id': 'FHKST03010100',
+        'custtype': 'P',
+      },
+    });
+
+    return new Response(JSON.stringify(response.data), { status: 200 });
+  } catch (error: unknown) {
+    console.error('API 요청 실패:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(JSON.stringify({ message: '데이터 가져오기 실패', error: errorMessage }), { status: 500 });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "mufin",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.9",
+        "chart.js": "^4.4.8",
+        "chartjs-adapter-date-fns": "^3.0.0",
+        "chartjs-chart-financial": "^0.2.1",
         "dotenv": "^16.4.7",
         "lucide-react": "^0.475.0",
         "next": "15.1.7",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "styled-components": "^6.1.15",
         "zod": "^3.24.2"
@@ -21,6 +26,8 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/styled-components": "^5.1.34",
+        "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^9",
         "eslint-config-next": "15.1.7",
         "prisma": "^6.4.0",
@@ -1427,6 +1434,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@next/env": {
       "version": "15.1.7",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.7.tgz",
@@ -1760,71 +1773,23 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stylis": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
       "license": "MIT"
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
-      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/tapable": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
-      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uglify-js": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
-      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@types/webpack": {
-      "version": "4.41.40",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.40.tgz",
-      "integrity": "sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tapable": "^1",
-        "@types/uglify-js": "*",
-        "@types/webpack-sources": "*",
-        "anymatch": "^3.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@types/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/source-list-map": "*",
-        "source-map": "^0.7.3"
-      }
-    },
-    "node_modules/@types/webpack-sources/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.24.1",
@@ -2309,6 +2274,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2333,6 +2304,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2461,7 +2443,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2544,6 +2525,37 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+      "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
+    "node_modules/chartjs-chart-financial": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/chartjs-chart-financial/-/chartjs-chart-financial-0.2.1.tgz",
+      "integrity": "sha512-RI3zrszyf2YdW7ME8I5XDsicy6YaU+uA1XZmGddR3rdcQlGf4pSgGFK8O0PWPO5Szdc8wZ8qpns++yib6pWBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.0.0"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2593,6 +2605,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -2712,6 +2736,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -2773,6 +2808,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2812,7 +2856,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2922,7 +2965,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2932,7 +2974,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2970,7 +3011,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2983,7 +3023,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3654,6 +3693,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3668,6 +3727,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -3689,7 +3763,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3741,7 +3814,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3766,7 +3838,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3854,7 +3925,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3933,7 +4003,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3946,7 +4015,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3962,7 +4030,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4654,7 +4721,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4682,6 +4748,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4793,10 +4880,10 @@
         }
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -5146,6 +5233,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5184,6 +5277,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "mufin",
       "version": "0.1.0",
       "dependencies": {
-        "axios": "^1.7.9",
         "chart.js": "^4.4.8",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-chart-financial": "^0.2.1",
@@ -2274,12 +2273,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2304,17 +2297,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2443,6 +2425,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2605,18 +2588,6 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -2808,15 +2779,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2856,6 +2818,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2965,6 +2928,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2974,6 +2938,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3011,6 +2976,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3023,6 +2989,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3693,26 +3660,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3727,21 +3674,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -3763,6 +3695,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3814,6 +3747,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3838,6 +3772,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3925,6 +3860,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4003,6 +3939,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4015,6 +3952,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4030,6 +3968,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4721,6 +4660,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4748,27 +4688,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5232,12 +5151,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.7.9",
+    "chart.js": "^4.4.8",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-chart-financial": "^0.2.1",
     "dotenv": "^16.4.7",
     "lucide-react": "^0.475.0",
     "next": "15.1.7",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "styled-components": "^6.1.15",
     "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "axios": "^1.7.9",
     "chart.js": "^4.4.8",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-chart-financial": "^0.2.1",


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
1. 1분 봉 그래프
- 개장 전, 마장 후 는 전날 15:15 기준 데이터로 불러옴
- 휴장일에는 어떻게 작동하는지 테스트는 못함
- 휴장일에는 데이터가 없을 것을 고려하여 데이터 없을 경우에는 휴장날입이다 모달 창 임시 구현
- 반복문으로 4번 30*4 = 120개 데이터 호출
- 롤링 방식 사용해서 분 봉 그래프 페이지에 있을 경우 1분 간격으로 api 호출

2. 일, 주, 월 봉 그래프
- 특이 사항 없이 작동

3. 년 봉 그래프
- 추후 각 주식별 상장일자 필요
- 현재는 삼성 상장일로 넣어두어 다른 주식 년 봉 데이터 조회할경우 오류나는게 당연함

4. 그래프 드래그 기능 추가

5. 그래프 색상 변경 불가능

6. 거래하기 버튼은 공통 컴포넌트 사용 예정
  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/818fc46e-986b-4d9d-8448-d31754b38304)
<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [#22]

<br/>
